### PR TITLE
Add Newbie Setting Screen & Change some color design

### DIFF
--- a/lib/components/curved_list_item.dart
+++ b/lib/components/curved_list_item.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-
-import '../style/styles.dart';
-import '../style/styles.dart';
+import 'package:flutter_jaram_together/style/styles.dart';
 
 class CurvedListItem extends StatelessWidget {
   const CurvedListItem({

--- a/lib/components/curved_list_item.dart
+++ b/lib/components/curved_list_item.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+import '../style/styles.dart';
+import '../style/styles.dart';
+
+class CurvedListItem extends StatelessWidget {
+  const CurvedListItem({
+    this.title,
+    this.time,
+    this.icon,
+    this.people,
+    this.color,
+    this.nextColor,
+    this.child,
+  });
+
+  final String title;
+  final String time;
+  final String people;
+  final IconData icon;
+  final Color color;
+  final Color nextColor;
+  final Widget child;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: nextColor,
+      child: Container(
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: const BorderRadius.only(
+            bottomLeft: Radius.circular(80.0),
+          ),
+          boxShadow: [wBoxshadow],
+        ),
+        padding: const EdgeInsets.only(
+          left: 32,
+          top: 80.0,
+          bottom: 50,
+        ),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/components/custom_text_field.dart
+++ b/lib/components/custom_text_field.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class CustomTextField extends StatelessWidget {
+  CustomTextField({
+    this.formKey,
+    this.validator,
+    this.textInputType,
+    this.onChanged,
+    this.onFieldSubmitted,
+    this.inputDecoration,
+    this.hintText,
+    this.labelText,
+    this.backgroundColor,
+    this.inputStyle,
+    this.cursorColor,
+    this.controller,
+    this.maxLength,
+    this.counterText,
+  });
+  final GlobalKey<FormState> formKey;
+  final TextInputType textInputType;
+  final Function validator;
+  final Function onChanged;
+  final Function onFieldSubmitted;
+  final InputDecoration inputDecoration;
+  final String hintText;
+  final String labelText;
+  final Color backgroundColor;
+  final TextStyle inputStyle;
+  final Color cursorColor;
+  final TextEditingController controller;
+  final int maxLength;
+  final String counterText;
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      autovalidate: false,
+      child: TextFormField(
+        controller: controller,
+        cursorColor: cursorColor,
+        style: inputStyle,
+        decoration: InputDecoration(
+          border: InputBorder.none,
+          hintText: hintText,
+          errorStyle: TextStyle(color: Colors.white),
+          labelStyle: TextStyle(color: Colors.grey[300]),
+          counterText: counterText,
+        ),
+        validator: validator,
+        keyboardType: textInputType,
+        onChanged: onChanged,
+        onFieldSubmitted: onFieldSubmitted,
+        maxLength: maxLength,
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_jaram_together/screens/Intro_screen.dart';
 import 'package:flutter_jaram_together/screens/login_screen.dart';
 import 'package:flutter_jaram_together/style/styles.dart';
 
@@ -15,9 +14,9 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       title: '너팟내팟',
       theme: ThemeData(
-        primarySwatch: mdarkBlue,
-        cardColor: kbannaColor,
-        accentColor: kdarkBlueColor,
+        primarySwatch: wskyBlueCrystalM,
+        cardColor: wmintCream,
+        accentColor: wskyBlueCrystal,
         cursorColor: Colors.brown,
         textTheme: TextTheme(
           display2: TextStyle(

--- a/lib/screens/Intro_screen.dart
+++ b/lib/screens/Intro_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_jaram_together/components/fade_route.dart';
-import 'package:flutter_jaram_together/screens/home_screen.dart';
+import 'package:flutter_jaram_together/screens/newbie_setting_screen.dart';
 import 'package:flutter_jaram_together/style/styles.dart';
 
 class IntroScreen extends StatefulWidget {
@@ -9,9 +9,9 @@ class IntroScreen extends StatefulWidget {
 }
 
 class _IntroScreenState extends State<IntroScreen> {
-  double opacity = kopacity;
-  double opacity2 = kopacity;
-  double opacity3 = kopacity;
+  double opacity = wopacity;
+  double opacity2 = wopacity;
+  double opacity3 = wopacity;
   @override
   void initState() {
     super.initState();
@@ -39,7 +39,7 @@ class _IntroScreenState extends State<IntroScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: kbannaColor,
+      backgroundColor: wmintCream,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(32.0),
@@ -51,7 +51,7 @@ class _IntroScreenState extends State<IntroScreen> {
                 duration: Duration(seconds: 1),
                 child: Text(
                   '안녕하세요!',
-                  style: TextStyle(fontSize: 28, fontWeight: FontWeight.w700),
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
                 ),
               ),
               SizedBox(
@@ -62,7 +62,7 @@ class _IntroScreenState extends State<IntroScreen> {
                 duration: Duration(seconds: 1),
                 child: Text(
                   '당신의 팟을 찾아줄 너팟내팟 이예요.',
-                  style: TextStyle(fontSize: 28, fontWeight: FontWeight.w700),
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
                 ),
               ),
               Spacer(),
@@ -74,7 +74,7 @@ class _IntroScreenState extends State<IntroScreen> {
                     duration: Duration(seconds: 1),
                     child: GestureDetector(
                       onTap: () {
-                        Navigator.pushReplacement(context, FadeRoute(page: HomeScreen()));
+                        Navigator.pushReplacement(context, FadeRoute(page: NewBieSettingScreen()));
                       },
                       child: Container(
                         padding: EdgeInsets.all(16.0),
@@ -83,7 +83,7 @@ class _IntroScreenState extends State<IntroScreen> {
                           style: TextStyle(fontWeight: FontWeight.w400),
                         ),
                         decoration: BoxDecoration(
-                          color: kdarkBlueColor,
+                          color: wskyBlueCrystal,
                           borderRadius: BorderRadius.circular(25.0),
                           boxShadow: [wBoxshadow],
                         ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -10,7 +10,7 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: kdarkBlueColor,
+      backgroundColor: wdarkBlueColor,
       body: SafeArea(
         child: Center(
           child: Text('HOME'),

--- a/lib/screens/newbie_setting_screen.dart
+++ b/lib/screens/newbie_setting_screen.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_jaram_together/components/curved_list_item.dart';
+import 'package:flutter_jaram_together/components/custom_text_field.dart';
+import 'package:flutter_jaram_together/style/styles.dart';
+
+import '../components/fade_route.dart';
+import '../style/styles.dart';
+
+class NewBieSettingScreen extends StatefulWidget {
+  @override
+  _NewBieSettingScreenState createState() => _NewBieSettingScreenState();
+}
+
+class _NewBieSettingScreenState extends State<NewBieSettingScreen> {
+  final nickNameController = TextEditingController();
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        FocusScope.of(context).requestFocus(new FocusNode());
+      },
+      child: Scaffold(
+        backgroundColor: wmintCream,
+        body: Column(
+          // crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CurvedListItem(
+              title: '이름을 알려주세요!',
+              color: wskyBlueCrystal,
+              nextColor: wmintCream,
+              child: Row(
+                children: [
+                  Text(
+                    '닉네임 : ',
+                    style: wscreenTitle,
+                  ),
+                  Flexible(
+                    child: CustomTextField(
+                      controller: nickNameController,
+                      textInputType: TextInputType.text,
+                      hintText: '여기에 이름을 알려주세요!',
+                      inputStyle: wscreenTitle,
+                      cursorColor: Colors.grey[600],
+                      onChanged: (value) {
+                        setState(() {});
+                      },
+                      maxLength: 5,
+                      counterText: "",
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Spacer(),
+            Row(
+              children: [
+                Spacer(),
+                Container(
+                  margin: EdgeInsets.all(16.0),
+                  child: GestureDetector(
+                    onTap: () {
+                      Navigator.pushReplacement(context, FadeRoute(page: NewBieSettingScreen()));
+                    },
+                    child: Container(
+                      padding: EdgeInsets.all(16.0),
+                      child: Text(
+                        nickNameController.text.length != 0 ? '설정완료!' : '이름을 설정해주세요!',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w800,
+                          color: Colors.white,
+                          fontSize: 12,
+                        ),
+                      ),
+                      decoration: BoxDecoration(
+                        color: wskyBlueCrystal,
+                        borderRadius: BorderRadius.circular(25.0),
+                        boxShadow: [wBoxshadow],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/newbie_setting_screen.dart
+++ b/lib/screens/newbie_setting_screen.dart
@@ -2,9 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_jaram_together/components/curved_list_item.dart';
 import 'package:flutter_jaram_together/components/custom_text_field.dart';
 import 'package:flutter_jaram_together/style/styles.dart';
-
-import '../components/fade_route.dart';
-import '../style/styles.dart';
+import 'package:flutter_jaram_together/components/fade_route.dart';
 
 class NewBieSettingScreen extends StatefulWidget {
   @override

--- a/lib/style/styles.dart
+++ b/lib/style/styles.dart
@@ -1,24 +1,41 @@
 import 'package:flutter/material.dart';
 
-const MaterialColor mdarkBlue = const MaterialColor(
+const MaterialColor wmintCreamM = const MaterialColor(
   0xFFFFFFFF,
   const <int, Color>{
-    50: const Color(0xff61a0af),
-    100: const Color(0xff61a0af),
-    200: const Color(0xff61a0af),
-    300: const Color(0xff61a0af),
-    400: const Color(0xff61a0af),
-    500: const Color(0xff61a0af),
-    600: const Color(0xff61a0af),
-    700: const Color(0xff61a0af),
-    800: const Color(0xff61a0af),
-    900: const Color(0xff61a0af),
+    50: const Color(0xffEFF7F6),
+    100: const Color(0xffEFF7F6),
+    200: const Color(0xffEFF7F6),
+    300: const Color(0xffEFF7F6),
+    400: const Color(0xffEFF7F6),
+    500: const Color(0xffEFF7F6),
+    600: const Color(0xffEFF7F6),
+    700: const Color(0xffEFF7F6),
+    800: const Color(0xffEFF7F6),
+    900: const Color(0xffEFF7F6),
+  },
+);
+const MaterialColor wskyBlueCrystalM = const MaterialColor(
+  0xFFFFFFFF,
+  const <int, Color>{
+    50: const Color(0xff71ccde),
+    100: const Color(0xff71ccde),
+    200: const Color(0xff71ccde),
+    300: const Color(0xff71ccde),
+    400: const Color(0xff71ccde),
+    500: const Color(0xff71ccde),
+    600: const Color(0xff71ccde),
+    700: const Color(0xff71ccde),
+    800: const Color(0xff71ccde),
+    900: const Color(0xff71ccde),
   },
 );
 
-const kdarkBlueColor = Color(0xff61a0af);
-const kbannaColor = Color(0xfff5d491);
-
+const wdarkBlueColor = Color(0xff61a0af);
+const wbannaColor = Color(0xfff5d491);
+const wmintCream = Color(0xffEFF7F6);
+const wceleste = Color(0xffB2F7EF);
+const wskyBlueCrystal = Color(0xff71ccde);
 BoxShadow wBoxshadow = BoxShadow(
   color: Color(0xFF1B1D1F).withOpacity(0.1),
   spreadRadius: 0,
@@ -26,4 +43,12 @@ BoxShadow wBoxshadow = BoxShadow(
   offset: Offset(0, 2), // changes position of shadow
 );
 
-const kopacity = 0.0;
+const wopacity = 0.0;
+
+const wscreenTitle = TextStyle(
+  // color: Color(0xFF424242),
+  color: Colors.white,
+  fontWeight: FontWeight.w800,
+  decoration: TextDecoration.none,
+  fontSize: 16,
+);


### PR DESCRIPTION
## Description  

이 PR은 Newbie Setting Screen 을 추가합니다.
이 화면은 사용자가 첫 가입 시 닉네임을 설정할 수 있도록 사용자에게 보여줍니다.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test environment

[✓] Flutter (Channel stable, 1.20.1, on Microsoft Windows [Version 10.0.18363.959], locale ko-KR)
[✓] Android toolchain - develop for Android devices (Android SDK version 29.0.3)
[✓] Android Studio (version 3.6)
[✓] Connected device (1 available)

## Major changes

**Before**

~~

**After**
**login Screen** & **Intro Screen** 도 아래의 사진과 같은 color 값 `0xffEFF7F6`, `0xff71ccde` 이 적용이 됩니다.  
  

![image](https://user-images.githubusercontent.com/51515055/90338692-610f6780-e026-11ea-8537-2e8b76261bcc.png)


## Etc
