### PR TITLE
Add store newbie information to firebase

### DIFF
--- a/lib/components/custom_text_field.dart
+++ b/lib/components/custom_text_field.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class CustomTextField extends StatelessWidget {
   CustomTextField({
@@ -16,6 +17,7 @@ class CustomTextField extends StatelessWidget {
     this.controller,
     this.maxLength,
     this.counterText,
+    this.inputFormatters,
   });
   final GlobalKey<FormState> formKey;
   final TextInputType textInputType;
@@ -31,11 +33,13 @@ class CustomTextField extends StatelessWidget {
   final TextEditingController controller;
   final int maxLength;
   final String counterText;
+  final List<TextInputFormatter> inputFormatters;
   @override
   Widget build(BuildContext context) {
     return Form(
       autovalidate: false,
       child: TextFormField(
+        inputFormatters: inputFormatters,
         controller: controller,
         cursorColor: cursorColor,
         style: inputStyle,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_jaram_together/screens/login_screen.dart';
+import 'package:flutter_jaram_together/screens/welcome_screen.dart';
 import 'package:flutter_jaram_together/style/styles.dart';
 
 void main() {
@@ -24,7 +24,7 @@ class MyApp extends StatelessWidget {
           ),
         ),
       ),
-      home: LoginScreen(),
+      home: WelcomeScreen(),
     );
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_jaram_together/components/fade_route.dart';
+import 'package:flutter_jaram_together/screens/login_screen.dart';
+import 'package:flutter_jaram_together/services/auth.dart';
+import 'package:flutter_jaram_together/services/sharedpref.dart';
 import 'package:flutter_jaram_together/style/styles.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -7,15 +11,50 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
+  Sharedpref sharedpref = Sharedpref();
+
+  @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+    updatePref();
+  }
+
+  void updatePref() async {
+    await sharedpref.updateStringSetting("user_last_screen", "home_screen");
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: wdarkBlueColor,
+      backgroundColor: wmintCream,
       body: SafeArea(
         child: Center(
-          child: Text('HOME'),
+          child: Column(
+            children: [
+              Text('HOME'),
+              FlatButton(
+                onPressed: () async {
+                  AuthHelper authHelper = AuthHelper();
+                  await authHelper.outCurrentuser();
+                  popupData();
+                  Navigator.pushReplacement(context, FadeRoute(page: LoginScreen()));
+                },
+                child: Text('로그아웃'),
+              )
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  void popupData() async {
+    await sharedpref.updateStringSetting("user_last_screen", "login_screen");
+    await sharedpref.updateStringSetting("user_uid", "");
+    await sharedpref.updateStringSetting("user_email", "");
+    await sharedpref.updateStringSetting("user_nickName", "");
+    await sharedpref.updateStringListSetting("user_podRole", []);
+    await sharedpref.updateStringListSetting("user_groupRole", []);
   }
 }

--- a/lib/screens/newbie_setting_screen.dart
+++ b/lib/screens/newbie_setting_screen.dart
@@ -1,8 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_jaram_together/components/curved_list_item.dart';
 import 'package:flutter_jaram_together/components/custom_text_field.dart';
+import 'package:flutter_jaram_together/screens/home_screen.dart';
+import 'package:flutter_jaram_together/services/database.dart';
+import 'package:flutter_jaram_together/services/sharedpref.dart';
+import 'package:flutter_jaram_together/services/user.dart';
 import 'package:flutter_jaram_together/style/styles.dart';
-import 'package:flutter_jaram_together/components/fade_route.dart';
+
+import '../components/fade_route.dart';
+import '../style/styles.dart';
 
 class NewBieSettingScreen extends StatefulWidget {
   @override
@@ -11,6 +18,18 @@ class NewBieSettingScreen extends StatefulWidget {
 
 class _NewBieSettingScreenState extends State<NewBieSettingScreen> {
   final nickNameController = TextEditingController();
+  Sharedpref sharedpref = Sharedpref();
+  @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+    updatePref();
+  }
+
+  void updatePref() async {
+    await sharedpref.updateStringSetting("user_last_screen", "newbie_setting_screen");
+  }
+
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
@@ -20,7 +39,6 @@ class _NewBieSettingScreenState extends State<NewBieSettingScreen> {
       child: Scaffold(
         backgroundColor: wmintCream,
         body: Column(
-          // crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             CurvedListItem(
               title: '이름을 알려주세요!',
@@ -44,6 +62,9 @@ class _NewBieSettingScreenState extends State<NewBieSettingScreen> {
                       },
                       maxLength: 5,
                       counterText: "",
+                      inputFormatters: [
+                        FilteringTextInputFormatter(RegExp(r"\s+"), allow: false),
+                      ],
                     ),
                   ),
                 ],
@@ -56,8 +77,30 @@ class _NewBieSettingScreenState extends State<NewBieSettingScreen> {
                 Container(
                   margin: EdgeInsets.all(16.0),
                   child: GestureDetector(
-                    onTap: () {
-                      Navigator.pushReplacement(context, FadeRoute(page: NewBieSettingScreen()));
+                    onTap: () async {
+                      DataBaseHelper dataBaseHelper = DataBaseHelper();
+
+                      final nickName = await sharedpref.getStringSetting("user_nickName");
+                      setState(() {});
+                      if (nickName == null || nickName == "") {
+                        await sharedpref.updateStringSetting("user_nickName", nickNameController.text);
+                        final userUid = await sharedpref.getStringSetting("user_uid");
+                        final userEmail = await sharedpref.getStringSetting("user_email");
+                        setState(() {});
+                        if (userUid == null || userUid == "") {
+                          print("error");
+                        } else {
+                          await dataBaseHelper.createUserData(User(
+                            id: userUid,
+                            nickName: nickNameController.text,
+                            email: userEmail,
+                            podRole: [],
+                            groupRole: [],
+                          ));
+                          Navigator.pushReplacement(context, FadeRoute(page: HomeScreen()));
+                        }
+                      }
+                      // remove empty string and saving
                     },
                     child: Container(
                       padding: EdgeInsets.all(16.0),

--- a/lib/screens/newbie_setting_screen.dart
+++ b/lib/screens/newbie_setting_screen.dart
@@ -7,9 +7,7 @@ import 'package:flutter_jaram_together/services/database.dart';
 import 'package:flutter_jaram_together/services/sharedpref.dart';
 import 'package:flutter_jaram_together/services/user.dart';
 import 'package:flutter_jaram_together/style/styles.dart';
-
-import '../components/fade_route.dart';
-import '../style/styles.dart';
+import 'package:flutter_jaram_together/components/fade_route.dart';
 
 class NewBieSettingScreen extends StatefulWidget {
   @override

--- a/lib/screens/welcome_screen.dart
+++ b/lib/screens/welcome_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_jaram_together/components/fade_route.dart';
+import 'package:flutter_jaram_together/screens/home_screen.dart';
+import 'package:flutter_jaram_together/screens/login_screen.dart';
+import 'package:flutter_jaram_together/screens/newbie_setting_screen.dart';
+import 'package:flutter_jaram_together/services/sharedpref.dart';
+import 'package:flutter_jaram_together/style/styles.dart';
+
+class WelcomeScreen extends StatefulWidget {
+  @override
+  _WelcomeScreenState createState() => _WelcomeScreenState();
+}
+
+class _WelcomeScreenState extends State<WelcomeScreen> {
+  Sharedpref sharedpref = Sharedpref();
+  @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+    preparingData();
+    checkingInitData();
+  }
+
+  void checkingInitData() async {
+    final userLastScreen = await sharedpref.getStringSetting("user_last_screen");
+    setState(() {});
+    print(userLastScreen);
+    if (userLastScreen == null || userLastScreen == "") {
+      await sharedpref.prepareStringSetting("user_last_screen", "login_screen");
+      Navigator.pushReplacement(context, FadeRoute(page: LoginScreen()));
+    } else {
+      if (userLastScreen == "login_screen") {
+        Navigator.pushReplacement(context, FadeRoute(page: LoginScreen()));
+      }
+      if (userLastScreen == "home_screen") {
+        Navigator.pushReplacement(context, FadeRoute(page: HomeScreen()));
+      }
+      if (userLastScreen == "newbie_setting_screen") {
+        Navigator.pushReplacement(context, FadeRoute(page: NewBieSettingScreen()));
+      }
+    }
+  }
+
+  void preparingData() async {
+    await sharedpref.prepareStringSetting("user_last_screen", "login_screen");
+    await sharedpref.prepareStringSetting("user_uid", "");
+    await sharedpref.prepareStringSetting("user_email", "");
+    await sharedpref.prepareStringSetting("user_nickName", "");
+    await sharedpref.prepareStringListSetting("user_podRole", []);
+    await sharedpref.prepareStringListSetting("user_groupRole", []);
+  }
+
+  @override
+  void deactivate() {
+    // TODO: implement deactivate
+    super.deactivate();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: wskyBlueCrystal,
+      body: Center(
+        child: Text(
+          '너팟내팟',
+          style: wscreenTitle.copyWith(fontSize: 32),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/auth.dart
+++ b/lib/services/auth.dart
@@ -1,5 +1,4 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/services.dart';
 
 class AuthHelper {
   AuthHelper({
@@ -83,6 +82,14 @@ class AuthHelper {
       final user = await _auth.currentUser();
       _loggedInUser = user;
       return _loggedInUser;
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  Future outCurrentuser() async {
+    try {
+      await _auth.signOut();
     } catch (e) {
       print(e);
     }

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -1,0 +1,25 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_jaram_together/services/user.dart';
+
+class DataBaseHelper {
+  final CollectionReference _usersCollectionReference = Firestore.instance.collection("usersInfo");
+  final _firestore = Firestore.instance;
+  Future createUserData(User user) async {
+    try {
+      await _usersCollectionReference.document(user.id).setData(user.toJson());
+    } catch (e) {
+      print(e);
+      return null;
+    }
+  }
+
+  Future getUserData(String uid) async {
+    try {
+      var userData = await _usersCollectionReference.document(uid).get();
+      return userData;
+    } catch (e) {
+      print(e);
+      return null;
+    }
+  }
+}

--- a/lib/services/sharedpref.dart
+++ b/lib/services/sharedpref.dart
@@ -1,0 +1,93 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class Sharedpref {
+  SharedPreferences sharedPrefs;
+  Future getBoolSetting(String prefName) async {
+    sharedPrefs = await SharedPreferences.getInstance();
+    String tmpString = "";
+    try {
+      tmpString = sharedPrefs.getBool(prefName) ?? "";
+      return tmpString;
+    } catch (e) {
+      print(e);
+      return null;
+    }
+  }
+
+  Future getStringSetting(String prefName) async {
+    sharedPrefs = await SharedPreferences.getInstance();
+    String tmpString = "";
+    try {
+      tmpString = sharedPrefs.getString(prefName) ?? "";
+      return tmpString;
+    } catch (e) {
+      print(e);
+      return null;
+    }
+  }
+
+  Future getStringListSetting(String prefName) async {
+    sharedPrefs = await SharedPreferences.getInstance();
+    List<String> tmpString = [];
+    try {
+      tmpString = sharedPrefs.getStringList(prefName) ?? [];
+      return tmpString;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  Future<void> prepareBoolSetting(String prefName, bool initVal) async {
+    sharedPrefs = await SharedPreferences.getInstance();
+    try {
+      sharedPrefs.getString(prefName) ?? await sharedPrefs.setBool(prefName, initVal);
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  Future<void> prepareStringSetting(String prefName, String initVal) async {
+    sharedPrefs = await SharedPreferences.getInstance();
+    try {
+      sharedPrefs.getString(prefName) ?? await sharedPrefs.setString(prefName, initVal);
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  Future<void> prepareStringListSetting(String prefName, List<String> initVal) async {
+    sharedPrefs = await SharedPreferences.getInstance();
+    try {
+      sharedPrefs.getStringList(prefName) ?? await sharedPrefs.setStringList(prefName, initVal);
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  Future<void> updateBoolSetting(String prefName, bool initVal) async {
+    sharedPrefs = await SharedPreferences.getInstance();
+    try {
+      await sharedPrefs.setBool(prefName, initVal);
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  Future<void> updateStringSetting(String prefName, String initVal) async {
+    sharedPrefs = await SharedPreferences.getInstance();
+    try {
+      await sharedPrefs.setString(prefName, initVal);
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  Future<void> updateStringListSetting(String prefName, List<String> initVal) async {
+    sharedPrefs = await SharedPreferences.getInstance();
+    try {
+      await sharedPrefs.setStringList(prefName, initVal);
+    } catch (e) {
+      print(e);
+    }
+  }
+}

--- a/lib/services/user.dart
+++ b/lib/services/user.dart
@@ -1,0 +1,23 @@
+class User {
+  User({this.id, this.nickName, this.email, this.podRole, this.groupRole});
+  final String id;
+  final String nickName;
+  final String email;
+  final List<String> podRole;
+  final List<String> groupRole;
+  User.fromData(Map<String, dynamic> data)
+      : id = data['id'],
+        nickName = data['nickName'],
+        email = data['email'],
+        podRole = data['podRole'],
+        groupRole = data['groupRole'];
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'nickName': nickName,
+      'email': email,
+      'podRole': podRole,
+      'groupRole': groupRole,
+    };
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -78,6 +78,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.2.1"
   firebase:
     dependency: transitive
     description:
@@ -177,6 +184,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.16.1"
   js:
     dependency: transitive
     description:
@@ -212,6 +226,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+2"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
   pedantic:
     dependency: transitive
     description:
@@ -219,6 +247,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -226,6 +261,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.13"
   provider:
     dependency: transitive
     description:
@@ -240,6 +282,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.8"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.2+1"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+10"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2+7"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -308,6 +385,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.8"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
 sdks:
   dart: ">=2.9.0-14.0.dev <3.0.0"
   flutter: ">=1.16.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   http: ^0.12.2
   firebase_auth: ^0.16.1
   cloud_firestore: ^0.13.7
+  shared_preferences: ^0.5.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

이 PR은 firebase 에 신규가입이 있을 시 데이터를 생성해주는 역할을 추가합니다.

**추가적으로 변경사항**
`custom_text_field.dart` 에서 입력 형식을 제한하는 방식이 추가되었습니다.
`newbie_setting_screen.dart` 에서 닉네임 입력 시 공백은 입력이 불가하게 추가되었습니다.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test environment

[√] Flutter (Channel stable, 1.20.1, on Microsoft Windows [Version 10.0.18363.1016], locale ko-KR)
[√] Android toolchain - develop for Android devices (Android SDK version 29.0.3)
[√] Android Studio (version 3.6)
[√] Connected device (1 available)

## Major changes

Please write code snippets or images

**Before**

~~

**After**

사용자 최근 화면 저장
`await sharedpref.updateStringSetting("user_last_screen", "login_screen");`
`await sharedpref.updateStringSetting("user_last_screen", "newbie_setting_screen");`
`await sharedpref.updateStringSetting("user_last_screen", "home_screen");`

첫 사용자 db 생성
```
await dataBaseHelper.createUserData(User(
                            id: userUid,
                            nickName: nickNameController.text,
                            email: userEmail,
                            podRole: [],
                            groupRole: [],
                          ));
```
## Etc
